### PR TITLE
Merge in favor of create 

### DIFF
--- a/docker/app/jobs/lib/loader/asset/graph_db_loader.rb
+++ b/docker/app/jobs/lib/loader/asset/graph_db_loader.rb
@@ -77,7 +77,7 @@ class GraphDbLoader
     %(
       MATCH (from:#{o.from_node}),(to:#{o.to_node})
       WHERE from.name = '#{o.from_name}' AND to.name = '#{o.to_name}'
-      CREATE (from)-[r:#{o.relationship} { last_updated: #{@last_updated} }]->(to)
+      MERGE (from)-[:#{_relationship_attrs(o)}]->(to)
     )
   end
 


### PR DESCRIPTION
Merge in favor of create  to avoid redundant relationships for global resources that appear in multiple regions.

Use relationship attributes helper.